### PR TITLE
feat: DXT配布に向けたタスク管理更新

### DIFF
--- a/docs/development/tasks.yml
+++ b/docs/development/tasks.yml
@@ -175,3 +175,33 @@
     - トラブルシューティングガイド
     - package.jsonのメタデータ整備
     - ライセンスファイルの追加
+
+# DXT配布準備
+- id: "dxt-001"
+  branch_name: "feature/dxt-distribution"
+  depends_on: ["docs-001"]
+  status: "todo"
+  overview: "DXTパッケージ作成と配布準備"
+  description: |
+    Claude Desktop、Windsurf等での ワンクリックインストールを可能にする
+    DXTパッケージを作成し、配布チャネルを整備する。
+  deliverables:
+    - DXT manifest.json の作成
+    - DXTビルドスクリプトの実装
+    - パッケージング自動化
+    - GitHub Releases での DXT 配布
+    - Claude Desktop での動作確認
+
+# タスク管理更新
+- id: "task-update-001" 
+  branch_name: "feature/task-management-update"
+  depends_on: []
+  status: "todo"
+  overview: "タスク管理システムの更新"
+  description: |
+    新しい配布タスク（DXT）の追加に伴い、タスク管理ファイルを更新する。
+    プロジェクトの進捗状況を正確に反映させる。
+  deliverables:
+    - tasks.yml への新タスク追加
+    - 依存関係の整理
+    - タスクステータスの更新


### PR DESCRIPTION
## 🎯 概要
DXT配布準備に向けて、新しいタスクをタスク管理システムに追加しました。

## 📋 追加されたタスク

### 🔧 DXT配布準備（dxt-001）
- **目的**: Claude Desktop、Windsurf向けワンクリックインストール対応
- **依存**: docs-001（ドキュメント整備）完了後
- **主要成果物**:
  - DXT manifest.json の作成
  - DXTビルドスクリプトの実装
  - パッケージング自動化
  - GitHub Releases での DXT 配布
  - Claude Desktop での動作確認

### 📊 タスク管理更新（task-update-001）
- **目的**: タスク管理プロセスの明文化
- **主要成果物**:
  - tasks.yml への新タスク追加
  - 依存関係の整理
  - タスクステータスの更新

## 🚀 次のステップ
1. このPRマージ後、dxt-001タスクに着手
2. DXTパッケージ作成とClaude Desktop対応
3. ワンクリックインストール機能の実現

## 📈 プロジェクト進捗
- ✅ 基本機能実装完了
- ✅ ドキュメント整備完了  
- 🔄 配布チャネル整備中（DXT優先）
- 🎯 目標：Claude Desktop/Windsurf での簡単インストール