### PR TITLE
feat: 通知機能改良とREADME多言語対応

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,21 +9,6 @@
     "url": "https://github.com/MySweetEden/notification-mcp"
   },
   "license": "MIT",
-  "homepage": "https://github.com/MySweetEden/notification-mcp",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/MySweetEden/notification-mcp.git"
-  },
-  "keywords": [
-    "mcp",
-    "model-context-protocol", 
-    "notification",
-    "sound",
-    "ai-assistant",
-    "claude",
-    "cursor",
-    "vscode"
-  ],
   "server": {
     "type": "node",
     "entry_point": "dist/index.js",
@@ -34,43 +19,5 @@
         "NODE_ENV": "production"
       }
     }
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "os": [
-    "darwin",
-    "win32"
-  ],
-  "files": [
-    "dist/",
-    "package.json",
-    "README.md",
-    "LICENSE"
-  ],
-  "mcp": {
-    "tools": [
-      {
-        "name": "playSound",
-        "description": "設定済みの音声ファイルを再生"
-      },
-      {
-        "name": "setSoundPath", 
-        "description": "通知音の音声ファイルパスを設定"
-      },
-      {
-        "name": "getSoundPath",
-        "description": "現在の音声ファイルパスを取得"
-      },
-      {
-        "name": "resetSoundPath",
-        "description": "音声設定をデフォルトに戻す"
-      },
-      {
-        "name": "showNotification",
-        "description": "デスクトップ通知を表示"
-      }
-    ]
-  },
-  "icon": "icon.png"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test:full": "node test-runner.js",
     "test:sound": "node -e \"const {SoundPlayer} = require('./dist/sound.js'); const player = new SoundPlayer(); player.playSound(player.getDefaultSoundPath()).then(console.log).catch(console.error);\"",
     "test:notification": "node -e \"const {NotificationManager} = require('./dist/notification.js'); const nm = new NotificationManager(); nm.showSimpleNotification('Test', 'テスト通知です').then(console.log).catch(console.error);\"",
+    "test:notification:diagnosis": "node test-notification-diagnosis.js",
+    "test:notification:permission": "node -e \"const {NotificationManager} = require('./dist/notification.js'); const nm = new NotificationManager(); nm.requestNotificationPermission().then(console.log).catch(console.error);\"",
     "test:interactive": "echo 'MCPサーバーを起動します。Ctrl+Cで終了してください。' && npm start",
     "prepublishOnly": "npm run clean && npm run build",
     "dxt:build": "npm run build && npx @anthropic-ai/dxt pack",

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           additionalProperties: false,
         },
       },
+
     ],
   };
 });

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -3,6 +3,11 @@
  * node-notifierライブラリを使用してOSネイティブな通知を表示
  */
 import notifier from "node-notifier";
+import * as os from "os";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
 
 export interface NotificationOptions {
   title: string;
@@ -13,45 +18,103 @@ export interface NotificationOptions {
 
 export class NotificationManager {
   /**
-   * デスクトップ通知を表示
+   * macOS用AppleScriptによる通知表示（フォールバック）
+   */
+  private async showNotificationWithAppleScript(title: string, message: string): Promise<string> {
+    try {
+      const script = `display notification "${message.replace(/"/g, '\\"')}" with title "${title.replace(/"/g, '\\"')}"`;
+      await execAsync(`osascript -e '${script}'`);
+      return `AppleScriptで通知を表示しました: ${title} - ${message}`;
+    } catch (error) {
+      throw new Error(`AppleScript通知エラー: ${error}`);
+    }
+  }
+
+  /**
+   * terminal-notifierによる通知表示（macOS推奨）
+   */
+  private async showNotificationWithTerminalNotifier(title: string, message: string): Promise<string> {
+    try {
+      // ターミナルのBundle IDを指定して確実に許可を得る
+      await execAsync(`terminal-notifier -message "${message.replace(/"/g, '\\"')}" -title "${title.replace(/"/g, '\\"')}" -sender com.apple.Terminal -timeout 10`);
+      return `terminal-notifierで通知を表示しました: ${title} - ${message}`;
+    } catch (error) {
+      throw new Error(`terminal-notifier通知エラー: ${error}`);
+    }
+  }
+
+  /**
+   * デスクトップ通知を表示（複数手法でフォールバック）
    */
   async showNotification(options: NotificationOptions): Promise<string> {
-    try {
-      return new Promise((resolve, reject) => {
-        const notificationOptions = {
-          title: options.title,
-          message: options.message,
-          sound: options.sound ?? false, // デフォルトは音なし（別途音声再生を使用）
-          wait: options.wait ?? false,
-          timeout: 10, // 10秒後に自動で消える
-          // macOS固有の設定
-          subtitle: `${Date.now()}`, // ユニークにするためのタイムスタンプ
-          contentImage: undefined, // 画像なし
-          open: undefined, // クリック時のアクション無効
-          // より確実に表示するための設定
-          sticky: false, // 自動で消える
-          hint: 'int:transient:1', // 一時的な通知として扱う
-        };
-        
-        console.error(`通知送信中: ${options.title} - ${options.message}`);
-        
-        notifier.notify(
-          notificationOptions,
-          (error, response) => {
-            if (error) {
-              console.error(`通知エラー詳細:`, error);
-              reject(new Error(`通知の表示に失敗しました: ${error.message}`));
-            } else {
-              console.error(`通知レスポンス:`, response);
-              resolve(`通知を表示しました: ${options.title} - ${options.message}`);
-            }
-          }
-        );
-      });
-    } catch (error) {
-      console.error(`通知システムエラー詳細:`, error);
-      throw new Error(`通知システムエラー: ${error}`);
+    const { title, message } = options;
+    console.error(`通知送信開始: ${title} - ${message}`);
+
+    // macOSの場合、複数の方法を試行
+    if (os.platform() === 'darwin') {
+      // 方法1: terminal-notifier（最も確実）
+      try {
+        const result = await this.showNotificationWithTerminalNotifier(title, message);
+        console.error(`✅ terminal-notifier成功: ${result}`);
+        return result;
+      } catch (error) {
+        console.error(`⚠️ terminal-notifier失敗:`, error);
+      }
+
+      // 方法2: AppleScript（フォールバック）
+      try {
+        const result = await this.showNotificationWithAppleScript(title, message);
+        console.error(`✅ AppleScript成功: ${result}`);
+        return result;
+      } catch (error) {
+        console.error(`⚠️ AppleScript失敗:`, error);
+      }
     }
+
+    // 方法3: node-notifier（最終フォールバック）
+    try {
+      return await this.showNotificationWithNodeNotifier(options);
+    } catch (error) {
+      console.error(`⚠️ node-notifier失敗:`, error);
+      throw new Error(`全ての通知方法が失敗しました。システム設定を確認してください。`);
+    }
+  }
+
+  /**
+   * node-notifierによる通知表示
+   */
+  private async showNotificationWithNodeNotifier(options: NotificationOptions): Promise<string> {
+    return new Promise((resolve, reject) => {
+      // シンプルな設定で確実性を重視
+      const notificationOptions = {
+        title: options.title,
+        message: options.message,
+        sound: options.sound ?? false,
+        wait: options.wait ?? false,
+        timeout: 15, // より長めのタイムアウト
+        // 問題を起こす可能性のある設定を削除
+        // subtitle: undefined,
+        // contentImage: undefined,
+        // open: undefined,
+        // sticky: false,
+        // hint: undefined,
+      };
+      
+      console.error(`node-notifier実行中: ${options.title} - ${options.message}`);
+      
+      notifier.notify(
+        notificationOptions,
+        (error, response) => {
+          if (error) {
+            console.error(`node-notifierエラー詳細:`, error);
+            reject(new Error(`node-notifier通知失敗: ${error.message}`));
+          } else {
+            console.error(`node-notifierレスポンス:`, response);
+            resolve(`node-notifierで通知を表示しました: ${options.title} - ${options.message}`);
+          }
+        }
+      );
+    });
   }
 
   /**
@@ -64,6 +127,114 @@ export class NotificationManager {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * 通知システムの診断情報を取得
+   */
+  async getDiagnostics(): Promise<string> {
+    const diagnostics: string[] = [];
+    diagnostics.push(`OS: ${os.platform()} ${os.release()}`);
+    diagnostics.push(`Node.js: ${process.version}`);
+    diagnostics.push(`node-notifier: 利用可能=${this.isNotificationSupported()}`);
+
+    if (os.platform() === 'darwin') {
+      // terminal-notifierの確認
+      try {
+        await execAsync('which terminal-notifier');
+        diagnostics.push(`terminal-notifier: ✅ インストール済み`);
+      } catch {
+        diagnostics.push(`terminal-notifier: ❌ 未インストール`);
+      }
+
+      // AppleScriptの確認
+      try {
+        await execAsync('which osascript');
+        diagnostics.push(`AppleScript: ✅ 利用可能`);
+      } catch {
+        diagnostics.push(`AppleScript: ❌ 利用不可`);
+      }
+    }
+
+    return diagnostics.join('\n');
+  }
+
+  /**
+   * 通知許可をリクエスト（macOS）
+   */
+  async requestNotificationPermission(): Promise<string> {
+    if (os.platform() !== 'darwin') {
+      return 'macOS以外では許可リクエストは不要です';
+    }
+
+    const results: string[] = [];
+    
+    try {
+      // 1. AppleScriptで許可リクエスト
+      await execAsync(`osascript -e 'display notification "通知許可のテストです" with title "Permission Request"'`);
+      results.push('✅ AppleScript通知許可: 成功');
+    } catch (error) {
+      results.push(`❌ AppleScript通知許可: 失敗 - ${error}`);
+    }
+
+    try {
+      // 2. terminal-notifierで許可リクエスト
+      await execAsync(`terminal-notifier -message "通知許可のテストです" -title "Permission Request" -sender com.apple.Terminal`);
+      results.push('✅ terminal-notifier通知許可: 成功');
+    } catch (error) {
+      results.push(`❌ terminal-notifier通知許可: 失敗 - ${error}`);
+    }
+
+    results.push('');
+    results.push('📋 次の手順:');
+    results.push('1. システム環境設定 > 通知とフォーカス を開く');
+    results.push('2. 左側のリストで「ターミナル」を探して選択');
+    results.push('3. 「通知を許可」をオンにする');
+    results.push('4. 通知スタイルを「バナー」または「アラート」に設定');
+    results.push('5. macOSを再起動（推奨）');
+
+    return results.join('\n');
+  }
+
+  /**
+   * 通知システムのフル診断テスト
+   */
+  async runDiagnosticTest(): Promise<string> {
+    const results: string[] = [];
+    const testTitle = "診断テスト";
+    const testMessage = `テスト実行時刻: ${new Date().toLocaleTimeString()}`;
+
+    results.push("=== 通知システム診断テスト ===");
+    results.push(await this.getDiagnostics());
+    results.push("");
+
+    if (os.platform() === 'darwin') {
+      // terminal-notifierテスト
+      try {
+        await this.showNotificationWithTerminalNotifier(testTitle, testMessage);
+        results.push("✅ terminal-notifier: 成功");
+      } catch (error) {
+        results.push(`❌ terminal-notifier: 失敗 - ${error}`);
+      }
+
+      // AppleScriptテスト
+      try {
+        await this.showNotificationWithAppleScript(testTitle, testMessage);
+        results.push("✅ AppleScript: 成功");
+      } catch (error) {
+        results.push(`❌ AppleScript: 失敗 - ${error}`);
+      }
+    }
+
+    // node-notifierテスト
+    try {
+      await this.showNotificationWithNodeNotifier({ title: testTitle, message: testMessage });
+      results.push("✅ node-notifier: 成功");
+    } catch (error) {
+      results.push(`❌ node-notifier: 失敗 - ${error}`);
+    }
+
+    return results.join('\n');
   }
 
   /**

--- a/test-notification-diagnosis.js
+++ b/test-notification-diagnosis.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/**
+ * 通知システム診断ツール
+ * macOS通知問題の原因を特定するための包括的診断
+ */
+
+const { NotificationManager } = require('./dist/notification.js');
+
+async function runDiagnosis() {
+  console.log('🔍 通知システム診断開始\n');
+
+  const nm = new NotificationManager();
+
+  try {
+    // 診断テスト実行
+    const diagnosticResults = await nm.runDiagnosticTest();
+    console.log(diagnosticResults);
+
+    console.log('\n=== 追加確認 ===');
+    
+    // 基本的な通知テスト
+    console.log('\n📢 基本通知テスト実行中...');
+    const result = await nm.showSimpleNotification('診断完了', '通知システムの診断が完了しました');
+    console.log(`結果: ${result}`);
+
+  } catch (error) {
+    console.error('❌ 診断中にエラーが発生:', error.message);
+  }
+
+  console.log('\n=== システム設定確認のお願い ===');
+  console.log('1. システム環境設定 > 通知とフォーカス');
+  console.log('2. ターミナル（またはNode.js）の通知許可を確認');
+  console.log('3. おやすみモードが無効になっているか確認');
+  console.log('4. 画面右上に通知が表示されているか確認');
+  console.log('\n通知が表示されない場合:');
+  console.log('- システム環境設定で通知を許可してください');
+  console.log('- ターミナルを再起動してください');
+  console.log('- macOSを再起動してください');
+}
+
+runDiagnosis().catch(console.error);
+


### PR DESCRIPTION
## 📋 概要

このPRでは、macOSでの通知表示問題とDXTパッケージのマニフェストエラーを修正し、さらにユーザビリティを向上させるためアラート機能を削除してシンプルな通知システムに統一しました。また、国際的なユーザー向けにREADMEの多言語対応も実装しました。

## 🛠️ 修正内容

### macOS通知許可問題の修正
- **sender指定**: terminal-notifierに `com.apple.Terminal` を指定
- **フォールバック機能強化**: terminal-notifier → AppleScript → node-notifier
- **許可リクエスト機能**: `npm run test:notification:permission`
- **診断ツール拡張**: より詳細な診断情報とトラブルシューティング

### DXTマニフェスト修正
- **Claude Desktopプレビューエラー解決**: 不要なキーを削除
- **最小限構成**: `engines`, `os`, `files`, `mcp` 等のキーを削除
- **DXTパッケージ作成**: 正常にビルドできるよう修正

### 🎯 アラート機能削除とシンプル化
- **❌ 削除**: `showAlert`ツールとモーダルダイアログ機能
- **✅ 改良**: 作業を中断しない自然な通知に統一
- **🔧 簡素化**: より使いやすいシンプルな通知システム

### 🌐 README多言語対応
- **🇯🇵 日本語版**: `README.md` (詳細な仕様書スタイル)
- **🇺🇸 英語版**: `README.en.md` (国際標準ドキュメント)
- **🔄 言語ナビゲーション**: 両言語間のスムーズな切り替え
- **📱 視覚的UI**: 絵文字による分かりやすい言語表示

## 🧪 テスト結果

### 通知機能
- ✅ `npm run test:notification:permission` - 許可リクエスト
- ✅ `npm run test:notification` - 基本通知テスト  
- ✅ `npm run test:notification:diagnosis` - 診断テスト

### DXTパッケージ
- ✅ `npx @anthropic-ai/dxt validate manifest.json` - マニフェスト検証
- ✅ `npm run dxt:build` - パッケージ作成
- ✅ Claude Desktopプレビューエラー解消

### 多言語ドキュメント
- ✅ GitHub標準的な言語切り替え構成
- ✅ 全セクションの英語翻訳完了
- ✅ 相互リンクの動作確認

## 🚀 利用可能機能

### 音声機能
- `playSound()` - 音声再生
- `setSoundPath(path)` - カスタム音声設定
- `getSoundPath()` - 音声設定確認
- `resetSoundPath()` - 設定リセット

### 通知機能（シンプル化済み）
- `showNotification(title, message)` - デスクトップ通知

## 📱 使用方法

### macOS通知設定
1. `npm run test:notification:permission` を実行
2. システム環境設定 > 通知とフォーカス > ターミナル で通知を許可
3. `showNotification("テスト", "通知が正常に動作しています！")` で確認

### DXTパッケージ
1. `npm run dxt:build` でパッケージ作成
2. 生成された .dxt ファイルをClaude Desktopにインストール
3. 通知機能をテスト

### 多言語ドキュメント
- **日本語**: `README.md` (デフォルト表示)
- **English**: `README.en.md` 
- 各ファイル上部のナビゲーションで言語切り替え

## ⚡ 互換性

- **macOS**: ✅ 完全対応（許可設定必須）
- **Windows**: ✅ 対応  
- **Node.js**: >=18.0.0
- **Claude Desktop**: ✅ DXTパッケージ対応
- **Languages**: 🇯🇵 日本語 / 🇺🇸 English

## 🎉 改良点

### ユーザビリティ
- より使いやすく、作業の邪魔にならないシンプルな通知システム
- モーダルダイアログによる作業中断がなくなり、自然な通知体験を提供

### 国際化
- 日本語・英語の完全な多言語対応により、グローバルなユーザーに対応
- GitHub標準的なドキュメント構成で、オープンソースプロジェクトとして国際的な貢献を促進